### PR TITLE
Battle Articles

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -95,6 +95,7 @@ OBJS := components/compression/malias.o \
      components/saveclock/friendliness_pellets.o components/saveclock/rtc.o \
      components/saveclock/initialize_save.o components/saveclock/integrity.o \
      components/saveclock/persistence.o \
+     components/encounter/articles.o \
      components/encounter/late_denjuu_statemachine.o \
      components/encounter/string_utils.o components/encounter/select_indicator.o \
      components/encounter/opponent_display_machine.o components/encounter/tile_digits.o \

--- a/components/encounter/articles.asm
+++ b/components/encounter/articles.asm
@@ -1,0 +1,82 @@
+INCLUDE "telefang.inc"
+
+SECTION "Temporary Article Pointer Table", ROMX[$5B00], BANK[$1C]
+Encounter_ADVICE_ArticleTable::
+; Temporary setup to be later replaced with a spreadsheet fed table.
+	dw .a, .a, .an, .a, .a, .a, .a, .a     ; 07
+	dw .a, .a, .a, .a, .a, .a, .a, .an     ; 0F
+	dw .a, .a, .a, .a, .an, .a, .a, .a     ; 17
+	dw .a, .an, .a, .a, .a, .a, .a, .a     ; 1F
+	dw .a, .a, .an, .a, .a, .a, .a, .a     ; 27
+	dw .a, .a, .a, .a, .a, .a, .a, .a      ; 2F
+	dw .a, .a, .a, .a, .a, .a, .a, .a      ; 37
+	dw .a, .an, .a, .a, .a, .a, .a, .a     ; 3F
+	dw .a, .a, .a, .a, .a, .an, .a, .a     ; 47
+	dw .a, .a, .an, .an, .a, .a, .a, .a    ; 4F
+	dw .an, .a, .a, .a, .a, .a, .a, .a     ; 57
+	dw .an, .an, .a, .a, .a, .a, .a, .an   ; 5F
+	dw .a, .a, .a, .a, .a, .a, .a, .a      ; 67
+	dw .a, .a, .a, .a, .a, .an, .an, .a    ; 6F
+	dw .a, .a, .a, .a, .an, .an, .an, .a   ; 77
+	dw .a, .a, .a, .a, .a, .a, .a, .an     ; 7F
+	dw .a, .a, .a, .a, .an, .a, .a, .an    ; 87
+	dw .a, .a, .a, .a, .an, .a, .a, .a     ; 8F
+	dw .a, .a, .a, .a, .a, .a, .an, .a     ; 97
+	dw .a, .a, .a, .a, .a, .a, .a, .a      ; 9F
+	dw .an, .a, .a, .an, .a, .a, .an, .a   ; A7
+	dw .a, .an, .a, .a, .a, .a, .nil, .nil ; AF
+	
+.a
+	db "A "
+	db $E0
+	
+.an
+	db "An "
+	db $E0
+	
+.nil
+	db $E0
+
+; To replace "call StringTable_LoadName75" at 1C:4666
+
+SECTION "Temporary Article Pointer Table", ROMX[$5AB0], BANK[$1C]
+Encounter_ADVICE_OpponentNameAndArticleLoader::
+	call StringTable_LoadName75
+	push af
+	push bc
+	push de
+	push hl
+	ld a, [W_StringTable_ROMTblIndex]
+	ld e, a
+	ld d, 0
+	sla e
+	rl d
+	ld hl, Encounter_ADVICE_ArticleTable
+	add hl, de
+	ld a, [hli]
+	ld c, a
+	ld a, [hli]
+	ld b, a
+	push bc
+	pop hl
+	ld de, W_Map_LocationStaging
+	ld b, $10
+	
+.copyLoop
+	ld a, [hli]
+	cp $E0
+	jr z, .abandonLoop
+	ld [de], a
+	inc de
+	dec b
+	jr nz, .copyLoop
+	
+.abandonLoop
+
+	ld a, $E0
+	ld [de], a
+	pop hl
+	pop de
+	pop bc
+	pop af
+	ret

--- a/components/encounter/opponent_display_machine.asm
+++ b/components/encounter/opponent_display_machine.asm
@@ -249,7 +249,7 @@ Encounter_SubStateDrawEncounterScreen::
     ld a, [W_Battle_OpponentParticipants + M_Battle_ParticipantSize * 0 + M_Battle_ParticipantSpecies]
     ld [W_StringTable_ROMTblIndex], a
     ld hl, StringTable_denjuu_species
-    call StringTable_LoadName75
+    call Encounter_ADVICE_OpponentNameAndArticleLoader
     call Encounter_CopyStagedStringToArg2
     
     ld a, [W_Encounter_BattleType]


### PR DESCRIPTION
This should handle the a/an side of things for issue 99. It only loads the text into WRAM (0:CCC0) though, an E5 code still needs to be added to the message for it to work. Also the "A" and "An" strings each include a trailing space so that no article for certain Denjuu can be possible without needless whitespace baggage.