### PR TITLE
Rewrite dependency scanner for speed (patch branch).

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,7 @@
 *.sav
 *.rtc
 
-;Prevent committing compiled object code
+;Prevent committing compiled object code.
 *.o
 *.2bpp
 *.1bpp
@@ -22,5 +22,8 @@
 *.sprite.bin
 *.atf
 
-;Prevent committing filesystem floatsam
+;Prevent committing build files.
+dependencies.d
+
+;Prevent committing filesystem flotsam.
 .DS_Store

--- a/Makefile
+++ b/Makefile
@@ -228,5 +228,8 @@ $(OBJS_MESSAGE) $(OBJS_MESSAGE_BLOCKS): $(SRC_MESSAGE)
 	@rm -f $@
 	@$(PYTHON) rip_scripts/rip_sgb_attrfile.py make_atf $< $@
 
-$(shell $(PYTHON) rip_scripts/scan_includes.py $(OBJS_ASM:.o=.asm) > dependencies.d)
+DEPENDENCY_SCAN_EXIT_STATUS := $(shell $(PYTHON) rip_scripts/scan_includes.py $(OBJS_ASM:.o=.asm) > dependencies.d; echo $$?)
+ifneq ($(DEPENDENCY_SCAN_EXIT_STATUS), 0)
+$(error Dependency scan failed)
+endif
 include dependencies.d

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,6 @@
 
 .SUFFIXES:
 .SUFFIXES: .asm .o .gbc .png .wav .wikitext
-.SECONDEXPANSION:
 
 # Build Telefang.
 # We have two targets:
@@ -160,18 +159,6 @@ OBJS_ASM := ${OBJS} ${OBJS_POWER} ${OBJS_SPEED}
 # If your default python is 3, you may want to change this to python3.
 PYTHON := rip_scripts/find_python.sh
 
-$(foreach obj, $(OBJS), \
-	$(eval $(obj:.o=)_dep := $(shell $(PYTHON) rip_scripts/scan_includes.py $(obj:.o=.asm))) \
-)
-
-$(foreach obj, $(OBJS_POWER), \
-	$(eval $(obj:.o=)_dep := $(shell $(PYTHON) rip_scripts/scan_includes.py $(obj:.o=.asm))) \
-)
-
-$(foreach obj, $(OBJS_SPEED), \
-	$(eval $(obj:.o=)_dep := $(shell $(PYTHON) rip_scripts/scan_includes.py $(obj:.o=.asm))) \
-)
-
 # Link objects together to build a rom.
 all: power speed
 
@@ -181,7 +168,7 @@ speed: $(ROMS_SPEED) $(ROMS_SPEED_NORTC)
 
 # Assemble source files into objects.
 # Use rgbasm -h to use halts without nops.
-$(OBJS_ASM): $$*.asm $$($$*_dep)
+$(OBJS_ASM): %.o: %.asm
 	rgbasm -h -o $@ $<
 
 $(ROMS_POWER): $(OBJS) $(OBJS_POWER) $(OBJS_MESSAGE) $(OBJS_MESSAGE_BLOCKS)
@@ -240,3 +227,6 @@ $(OBJS_MESSAGE) $(OBJS_MESSAGE_BLOCKS): $(SRC_MESSAGE)
 %.atf: %.sgbattr.csv
 	@rm -f $@
 	@$(PYTHON) rip_scripts/rip_sgb_attrfile.py make_atf $< $@
+
+$(shell $(PYTHON) rip_scripts/scan_includes.py $(OBJS_ASM:.o=.asm) > dependencies.d)
+include dependencies.d

--- a/rip_scripts/scan_includes.py
+++ b/rip_scripts/scan_includes.py
@@ -1,37 +1,64 @@
-#!/bin/python
-# coding: utf-8
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
 
-"""
-Recursively scan an asm file for dependencies.
-Highly modified version of the PRET (Pokemon Reverse Engineering Tools) ver
+"""Get all the dependencies of RGBDS assembly files recursively,
+and output them using Make dependency syntax.
 """
 
+# This approach adapted from nowhere - 100% artisanal @obskyr solution 😎👌
+
+from __future__ import print_function
+from __future__ import unicode_literals
+
+import os
+import re
 import sys
-import argparse
-import os.path
 
-includes = set()
+INCLUDE_RE = re.compile(r"^\s*(INC(?:LUDE|BIN))", re.IGNORECASE)
 
-def scan_file(filename):
-	for line in open(filename, encoding="utf-8"):
-		if 'INC' not in line.upper():
-			continue
-		line = line.split(';')[0]
-		if 'INCLUDE' in line.upper():
-			include = line.split('"')[1]
-			includes.add(include)
-			scan_file(include)
-		elif 'INCBIN' in line.upper():
-			include = line.split('"')[1]
-			includes.add(include)
+def dependencies_in(asm_file_paths):
+    asm_file_paths = list(asm_file_paths)
+    dependencies = {}
+    
+    for path in asm_file_paths:
+        if path not in dependencies:
+            asm_dependencies, bin_dependencies = shallow_dependencies_of(path)
+            dependencies[path] = asm_dependencies | bin_dependencies
+            asm_file_paths += asm_dependencies
+    
+    return dependencies
+
+def shallow_dependencies_of(asm_file_path):
+    asm_dependencies = set()
+    bin_dependencies = set()
+
+    with open(asm_file_path, 'r') as f:
+        for line in f:
+            m = INCLUDE_RE.match(line)
+            if m is None:
+                continue
+            
+            keyword = m.group(1).upper()
+            line = line.split(';', 1)[0]
+            path = line[line.index('"') + 1:line.rindex('"')]
+            if keyword == 'INCLUDE':
+                asm_dependencies.add(path)
+            else:
+                bin_dependencies.add(path)
+    
+    return asm_dependencies, bin_dependencies
 
 def main():
-	ap = argparse.ArgumentParser()
-	ap.add_argument('filenames', nargs='*')
-	args = ap.parse_args()
-	for filename in set(args.filenames):
-		scan_file(filename)
-	sys.stdout.write(' '.join(includes))
+    if not len(sys.argv) > 1:
+        print("Usage: {} <paths to assembly files...>".format(os.path.basename(__file__)))
+        sys.exit(1)
+    
+    for path, dependencies in dependencies_in(sys.argv[1:]).items():
+        # It seems that if A depends on B which depends on C, and
+        # C is modified, Make needs you to change the modification
+        # time of B too. That's the reason for the "@touch $@".
+        if dependencies:
+            print("{}: {}\n\t@touch $@".format(path, ' '.join(dependencies)))
 
 if __name__ == '__main__':
-	main()
+    main()


### PR DESCRIPTION
This cuts down the startup time for each build from ~30 seconds to just about... 0.5 seconds. That's pretty good!

This speedup was achieved by a change in approach: before, the dependency scanner was run once for every assembly file, and it went through and parsed the files' dependency trees every time. This rewrite only runs once, and never parses included files more than once.