### PR TITLE
Option Positioning Shorthand

### DIFF
--- a/components/mainscript/ccinterpreter.asm
+++ b/components/mainscript/ccinterpreter.asm
@@ -47,7 +47,7 @@ MainScript_CCInterpreter::
 	
 .cursorResetRelativeOffsetCC
 	cp $EF
-	jr nz, .localStateJumpCC
+	jr nz, .arrowPositionCC
 	xor a
 	
 .cursorSetRelativeOffset

--- a/script/story/all.messages.csv
+++ b/script/story/all.messages.csv
@@ -516,11 +516,11 @@ Und wer weiß, vielleicht erfahren wir dabei das ein oder andere über diese Wel
 There is nothing to be afraid of.
 I am not going to eat you, or any such thing.
 Now then, are you familiar with the Denjuu World?
-<0>Yes  <0>No<*A>",,"Hohoho.
+<0>Yes<0xF0>No<*A>",,"Hohoho.
 Ihr braucht wirklich keine Angst zu haben.
 Ich werde euch schon nicht auffressen.
 Wisst ihr über unsere Welt überhaupt Bescheid?
-<0>Ja   <0>Nein<*A>",,
+<0>Ja<0xF0>Nein<*A>",,
 0x120118,"ではまず デンジュウカイに
 ついて はなそうかの","Ah, then I suppose I should explain.",,"Nein? Gut, dann lasst mich euch was darüber erzählen.",,
 0x12011a,"ニンゲンカイと デンジュウカイ
@@ -573,9 +573,9 @@ Diese Kämpfe, die ausschließlich zwischen Denjuu ausgefochten werden, bezeichn
 わかったかな?
  はい  いいえ<*A>","So?
 Do you understand now?
-<0>Yes  <0>No<*A>",,"Und?
+<0>Yes<0xF0>No<*A>",,"Und?
 Habt ihr soweit alles verstanden?
-<0>Ja   <0>Nein<*A>",,
+<0>Ja<0xF0>Nein<*A>",,
 0x120128,"では おぬしらを ここによんだ
 リゆうを はなそうかの",Then we shall discuss the reason you were called here.,,"Gut, dann sollten wir nun über das reden, weshalb ihr überhaupt hierher gerufen wurdet.",,
 0x12012a,"このむらのすいげんに 


### PR DESCRIPTION
This should turn the absurd "<0>Yes<0xEE><P1><0>No<*A>" I had before into "<0>Yes<0xF0>No<*A>". This should be quite useful for single-line question options. The old control codes will also stick around for positioning "item obtained" messages and for multi-line answers (where you want both top and bottom lines to line up).

Effectively this positions the second arrow as well as positions the text with enough space for the arrow.

I have also added a test case for the arrows, namely the Y/N question Musa asks during the intro.