### PR TITLE
Story text fixes

### DIFF
--- a/script/story/all.messages.csv
+++ b/script/story/all.messages.csv
@@ -339,7 +339,7 @@ Dショットが なかったら
 デンジュウカイにもいけないし
 デンジュウたちとも トモダチに
 なれないんだろ?","Yeah, but we don't have a D-Shot.
-Without a D-Shot, we can't go to the Denjuu World, and you won't be able to make friends with any of them, right?",,
+Without a D-shot, we can't go to the Denjuu World, and you won't be able to make friends with any of them, right?",,
 0x1200f2,"ん?デンワが なっていますね
 あの きのしたからでしょうか?","Hm? I can hear a phone ringing...
 Is it coming from under that tree?",,
@@ -1261,7 +1261,7 @@ Let's mess her plans right up, now! Right up, right up!",,
 おきなさい!
 そのかわリ せんきょのときは
 『きよきいっぴょう』を!","That doesn't matter now!!
-If you're thinking of getting in her way, I will gladly help you out!
+If you're thinking of getting in her way, I will glady help you out!
 Oh! That's right!
 This is a just between you and me, kid, but you need a key to get to the center of this cavern.
 Here, I'll give it to you! As a present!

--- a/script/story/all.messages.csv
+++ b/script/story/all.messages.csv
@@ -339,7 +339,7 @@ Dショットが なかったら
 デンジュウカイにもいけないし
 デンジュウたちとも トモダチに
 なれないんだろ?","Yeah, but we don't have a D-Shot.
-Without a D-shot, we can't go to the Denjuu World, and you won't be able to make friends with any of them, right?",,
+Without a D-Shot, we can't go to the Denjuu World, and you won't be able to make friends with any of them, right?",,
 0x1200f2,"ん?デンワが なっていますね
 あの きのしたからでしょうか?","Hm? I can hear a phone ringing...
 Is it coming from under that tree?",,
@@ -1261,7 +1261,7 @@ Let's mess her plans right up, now! Right up, right up!",,
 おきなさい!
 そのかわリ せんきょのときは
 『きよきいっぴょう』を!","That doesn't matter now!!
-If you're thinking of getting in her way, I will glady help you out!
+If you're thinking of getting in her way, I will gladly help you out!
 Oh! That's right!
 This is a just between you and me, kid, but you need a key to get to the center of this cavern.
 Here, I'll give it to you! As a present!


### PR DESCRIPTION
- Made the capitalization of "D-Shot" (from the first cutscene) more consistent with other instances of D-Shot.
- Fixed a typo from Mr. Nerikara in Northeast Cavern.